### PR TITLE
Permissions fix for containerized environments (Sail)

### DIFF
--- a/src/Pastel.php
+++ b/src/Pastel.php
@@ -107,7 +107,7 @@ class Pastel
 
         $renderer = new BladeRenderer(
             [__DIR__ . '/../resources/views'],
-            ['cache_path' => __DIR__.'/_tmp']
+            ['cache_path' => '/tmp']
         );
         $output = $renderer->render('index', [
             'page' => $metadata,


### PR DESCRIPTION
This small pull request fixes a bug with permissions inside a Docker container.

I'm not sure if it's WSL 2 specific or Sail specific or just permissions in general, but for some reason, it couldn't generate HTML files successfully and it kept throwing an exception. Exception trace is below.
<details>
<summary>Trace</summary>

```
🔊 info Processing route: [GET] api/providers
👍 success Processed route: [GET] api/providers
🔊 info Processing route: [POST] api/providers
👍 success Processed route: [POST] api/providers
🔊 info Processing route: [GET] api/providers/{provider}
👍 success Processed route: [GET] api/providers/{provider}
🔊 info Processing route: [PUT,PATCH] api/providers/{provider}
👍 success Processed route: [PUT,PATCH] api/providers/{provider}
🔊 info Processing route: [DELETE] api/providers/{provider}
👍 success Processed route: [DELETE] api/providers/{provider}
🔊 info Processing route: [GET] api/resources
👍 success Processed route: [GET] api/resources
🔊 info Processing route: [POST] api/resources
👍 success Processed route: [POST] api/resources
🔊 info Processing route: [GET] api/resources/{resource}
👍 success Processed route: [GET] api/resources/{resource}
🔊 info Processing route: [PUT,PATCH] api/resources/{resource}
👍 success Processed route: [PUT,PATCH] api/resources/{resource}
🔊 info Processing route: [DELETE] api/resources/{resource}
👍 success Processed route: [DELETE] api/resources/{resource}
🔊 info Processing route: [GET] api/providers/{provider}/resources
👍 success Processed route: [GET] api/providers/{provider}/resources
🔊 info Processing route: [POST] api/providers/{provider}/resources
👍 success Processed route: [POST] api/providers/{provider}/resources
🔊 info Writing source Markdown files to: resources/docs
🔊 info Wrote source Markdown files to: resources/docs
🔊 info Transforming Markdown docs to HTML...

   ErrorException

  mkdir(): Permission denied

  at vendor/windwalker/renderer/BladeRenderer.php:296
    292▕                 throw new \InvalidArgumentException('Please set cache_path into config.');
    293▕             }
    294▕
    295▕             if (!is_dir($cachePath)) {
  ➜ 296▕                 mkdir($cachePath, 0755, true);
    297▕             }
    298▕
    299▕             $this->compiler = new CompilerEngine(new BladeCompiler($this->getFilesystem(), $cachePath));
    300▕         }

  1   vendor/windwalker/renderer/BladeRenderer.php:296
      mkdir()

  2   vendor/windwalker/renderer/BladeRenderer.php:111
      Windwalker\Renderer\BladeRenderer::getCompiler()

  3   vendor/windwalker/renderer/BladeRenderer.php:95
      Windwalker\Renderer\BladeRenderer::getEngine()

  4   vendor/knuckleswtf/pastel/src/Pastel.php:114
      Windwalker\Renderer\BladeRenderer::render()

  5   vendor/knuckleswtf/scribe/src/Writing/Writer.php:290
      Knuckles\Pastel\Pastel::generate()

  6   vendor/knuckleswtf/scribe/src/Writing/Writer.php:107
      Knuckles\Scribe\Writing\Writer::writeHtmlDocs()

  7   vendor/knuckleswtf/scribe/src/Commands/GenerateDocumentation.php:83
      Knuckles\Scribe\Writing\Writer::writeDocs()

  8   vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36
      Knuckles\Scribe\Commands\GenerateDocumentation::handle()

  9   vendor/laravel/framework/src/Illuminate/Container/Util.php:40
      Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()

  10  vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:93
      Illuminate\Container\Util::unwrapIfClosure()

  11  vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:37
      Illuminate\Container\BoundMethod::callBoundMethod()

  12  vendor/laravel/framework/src/Illuminate/Container/Container.php:610
      Illuminate\Container\BoundMethod::call()

  13  vendor/laravel/framework/src/Illuminate/Console/Command.php:136
      Illuminate\Container\Container::call()

  14  vendor/symfony/console/Command/Command.php:256
      Illuminate\Console\Command::execute()

  15  vendor/laravel/framework/src/Illuminate/Console/Command.php:121
      Symfony\Component\Console\Command\Command::run()

  16  vendor/symfony/console/Application.php:971
      Illuminate\Console\Command::run()

  17  vendor/symfony/console/Application.php:290
      Symfony\Component\Console\Application::doRunCommand()

  18  vendor/symfony/console/Application.php:166
      Symfony\Component\Console\Application::doRun()

  19  vendor/laravel/framework/src/Illuminate/Console/Application.php:92
      Symfony\Component\Console\Application::run()

  20  vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:129
      Illuminate\Console\Application::run()

  21  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
```

</details>

Note that this is a fast fix, it probably could've been fixed in a more elegant way (using Docker or something), but this what I had come up with in a few minutes (excluding messing with Composer). I'm using the fork in my work project and works fine.